### PR TITLE
Adapt to Mac OSX

### DIFF
--- a/CrawlingFund.py
+++ b/CrawlingFund.py
@@ -5,7 +5,12 @@
 import os
 import time
 import traceback
-from multiprocessing import Queue, Event
+import sys
+from multiprocessing import Event
+if 'darwin' in sys.platform:
+    from methods import Queue
+else:
+    from multiprocessing import Queue
 
 from requests.exceptions import RequestException
 

--- a/methods.py
+++ b/methods.py
@@ -1,0 +1,62 @@
+import multiprocessing
+import multiprocessing.queues
+
+
+class SharedCounter(object):
+    """ A synchronized shared counter.
+    The locking done by multiprocessing.Value ensures that only a single
+    process or thread may read or write the in-memory ctypes object. However,
+    in order to do n += 1, Python performs a read followed by a write, so a
+    second process may read the old value before the new one is written by the
+    first process. The solution is to use a multiprocessing.Lock to guarantee
+    the atomicity of the modifications to Value.
+    This class comes almost entirely from Eli Bendersky's blog:
+    http://eli.thegreenplace.net/2012/01/04/shared-counter-with-pythons-multiprocessing/
+    """
+
+    def __init__(self, n = 0):
+        self.count = multiprocessing.Value('i', n)
+
+    def increment(self, n = 1):
+        """ Increment the counter by n (default = 1) """
+        with self.count.get_lock():
+            self.count.value += n
+
+    @property
+    def value(self):
+        """ Return the value of the counter """
+        return self.count.value
+
+
+class Queue(multiprocessing.queues.Queue):
+    """ A portable implementation of multiprocessing.Queue.
+    Because of multithreading / multiprocessing semantics, Queue.qsize() may
+    raise the NotImplementedError exception on Unix platforms like Mac OS X
+    where sem_getvalue() is not implemented. This subclass addresses this
+    problem by using a synchronized shared counter (initialized to zero) and
+    increasing / decreasing its value every time the put() and get() methods
+    are called, respectively. This not only prevents NotImplementedError from
+    being raised, but also allows us to implement a reliable version of both
+    qsize() and empty().
+    """
+
+    def __init__(self, *args, **kwargs):
+        ctx = multiprocessing.get_context()
+        super(Queue, self).__init__(*args, **kwargs, ctx=ctx)
+        self.size = SharedCounter(0)
+
+    def put(self, *args, **kwargs):
+        self.size.increment(1)
+        super(Queue, self).put(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        self.size.increment(-1)
+        return super(Queue, self).get(*args, **kwargs)
+
+    def qsize(self):
+        """ Reliable implementation of multiprocessing.Queue.qsize() """
+        return self.size.value
+
+    def empty(self):
+        """ Reliable implementation of multiprocessing.Queue.empty() """
+        return not self.qsize()


### PR DESCRIPTION
Hi there, I'm so interested in your project on Funds. However, it raises exceptions when I run this project on my Mac.
It takes few hours to work it through, and here it is.

I try to prevent Queue.qsize() from raising NotImplementedError on Mac OS X
The original idea comes from vterron/lemon@9ca6b4b